### PR TITLE
Remove dead guide link

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -3,7 +3,8 @@ description: Adds endpoint reporting health checks in Nagios format
 metadata:
   keywords:
     - nagios
-  guide: https://quarkiverse.github.io/quarkiverse-docs/nagios/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+# To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+# guide: https://quarkiverse.github.io/quarkiverse-docs/nagios/dev/ 
   categories:
     - "miscellaneous"
   status: "preview"

--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -3,8 +3,7 @@ description: Adds endpoint reporting health checks in Nagios format
 metadata:
   keywords:
     - nagios
-# To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
-# guide: https://quarkiverse.github.io/quarkiverse-docs/nagios/dev/ 
+  guide: https://docs.quarkiverse.io/quarkus-nagios/dev/
   categories:
     - "miscellaneous"
   status: "preview"


### PR DESCRIPTION
At the moment, https://docs.quarkiverse.io/nagios/dev/ is not live. This change removes the dead guide link. Alternatively, https://hub.quarkiverse.io/documentingyourextension/ has instructions for publishing this extension.